### PR TITLE
Fixed broken links via awesome-lists-bot

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,6 @@
 * [Introduction to Gulp.js](http://stefanimhoff.de/tag/gulp/)
 * [Video: Learning Gulp](http://leveluptuts.com/tutorials/learning-gulp)
 * [Using Gulp to Inject Scripts and Styles Tags Directly into Your HTML](http://blog.johnnyreilly.com/2015/02/using-gulp-in-asp-net-instead-of-web-optimization.html)
-* [5 Lessons Learned Using Gulp.js](http://denbuzze.com/post/5-lessons-learned-using-gulpjs/)
 * [Automating Linkage: How I Learned to Stop Worrying and Love the Build](http://lab.brightnorth.co.uk/2014/08/13/automating-linkage-how-i-learned-to-stop-worrying-and-love-the-build/)
 * [Setting Up Gulp Tasks for the First Time](https://www.codementor.io/development-process/tutorial/how-to-set-up-gulp-beginner-guide#/)
 * [Why You Shouldn’t Create a Gulp Plugin (or, How to Stop Worrying and Learn to Love Existing Node Packages)](http://blog.overzealous.com/post/74121048393/why-you-shouldnt-create-a-gulp-plugin-or-how-to)
@@ -98,7 +97,6 @@
 
 #### Gulp with React and Browserify
 * [Browserify and Gulp with React](https://hacks.mozilla.org/2014/08/browserify-and-gulp-with-react/)
-* [Taking React to the Next Level: Mixins, Gulp, and Browserify](http://pomax.github.io/1420592591221/taking-react-to-the-next-level-mixins-gulp-and-browserify)
 
 #### Gulp with Ember
 * [Improving Your Ember.js Workflow Using Gulp.js](http://www.sitepoint.com/improving-ember-js-workflow-using-gulp-js/)
@@ -136,7 +134,6 @@
 * [gulp-csso](https://github.com/ben-eb/gulp-csso) - Minify CSS with [CSSO](https://github.com/css/csso).
 * [gulp-uglify](https://github.com/terinjokes/gulp-uglify) - Minify JavaScript with [UglifyJS2](https://github.com/mishoo/UglifyJS2).
 * [gulp-htmlmin](https://github.com/jonschlinkert/gulp-htmlmin) - Minify HTML with [html-minifier](https://github.com/kangax/html-minifier).
-* [gulp-minify-html](https://github.com/murphydanger/gulp-minify-html) - Minify HTML with
  [Minimize](https://github.com/Swaagie/minimize).
 * [gulp-imagemin](https://github.com/sindresorhus/gulp-imagemin) - Minify PNG, JPEG, GIF and SVG images with [imagemin](https://github.com/imagemin/imagemin).
 * [gulp-svgmin](https://github.com/ben-eb/gulp-svgmin) - Minify SVG files with gulp.


### PR DESCRIPTION
This Pull Request has been generated automatically by awesome-lists-bot, which was created by @ColinEberhardt. The aim of this bot is to improve the overall standard of the various GitHub-based 'awesome' lists.

For questions / comments regarding the bot, or to have your awesome repo removed from the list, please add an issue here:

https://github.com/ColinEberhardt/awesome-lists-bot

Currently the bot does the following:
- Removes links that returns 404s (please double check these deletions before merging in case it is a temporary issue)

More features are on the way ...
- Add a star count for repos, this helps people find popular projects (especially useful for big lists!)
- Resolve redirects, updating the project / org name when a redirect is found.

Here's a summary of changes as part of this PR:

Awesome link checker verified 156 links, finding 3 broken
- [404] http://denbuzze.com/post/5-lessons-learned-using-gulpjs/
- [404] http://pomax.github.io/1420592591221/taking-react-to-the-next-level-mixins-gulp-and-browserify
- [404] https://github.com/murphydanger/gulp-minify-html
